### PR TITLE
Make (tx,rx) for TUI an Option

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -18,7 +18,7 @@ pub fn initialize_algorithm<S>(
     engine: Engine<S>,
     settings: Settings,
     scenarios: Vec<Scenario>,
-    tx: mpsc::UnboundedSender<Comm>,
+    tx: Option<mpsc::UnboundedSender<Comm>>,
 ) -> Box<dyn Algorithm>
 where
     S: Predict<'static> + std::marker::Sync + Clone + 'static,

--- a/src/algorithms/npag.rs
+++ b/src/algorithms/npag.rs
@@ -48,7 +48,7 @@ where
     cache: bool,
     scenarios: Vec<Scenario>,
     c: (f64, f64, f64, f64),
-    tx: UnboundedSender<Comm>,
+    tx: Option<UnboundedSender<Comm>>,
     settings: Settings,
 }
 
@@ -98,7 +98,7 @@ where
         theta: Array2<f64>,
         scenarios: Vec<Scenario>,
         c: (f64, f64, f64, f64),
-        tx: UnboundedSender<Comm>,
+        tx: Option<UnboundedSender<Comm>>,
         settings: Settings,
     ) -> Self
     where
@@ -281,7 +281,10 @@ where
                 theta: self.theta.clone(),
                 gamlam: self.gamma,
             };
-            self.tx.send(Comm::NPCycle(state.clone())).unwrap();
+            match &self.tx {
+                Some(tx) => tx.send(Comm::NPCycle(state.clone())).unwrap(),
+                None => (),
+            }
 
             // Increasing objf signals instability or model misspecification.
             if self.last_objf > self.objf {

--- a/src/algorithms/postprob.rs
+++ b/src/algorithms/postprob.rs
@@ -34,7 +34,7 @@ where
     scenarios: Vec<Scenario>,
     c: (f64, f64, f64, f64),
     #[allow(dead_code)]
-    tx: UnboundedSender<Comm>,
+    tx: Option<UnboundedSender<Comm>>,
     settings: Settings,
 }
 
@@ -68,7 +68,7 @@ where
         theta: Array2<f64>,
         scenarios: Vec<Scenario>,
         c: (f64, f64, f64, f64),
-        tx: UnboundedSender<Comm>,
+        tx: Option<UnboundedSender<Comm>>,
         settings: Settings,
     ) -> Self
     where


### PR DESCRIPTION
Avoid the `drop_messages()`-approach when the TUI is not used, improving the interface.