### PR TITLE
Minor rework of outputs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rs text eol=lf

--- a/src/algorithms/npag.rs
+++ b/src/algorithms/npag.rs
@@ -282,9 +282,10 @@ where
             // Increasing objf signals instability or model misspecification.
             if self.last_objf > self.objf {
                 tracing::warn!(
-                    "Objective function decreased from {} to {}",
-                    self.last_objf,
-                    self.objf
+                    "Objective function decreased from {:.4} to {:.4} (delta = {})",
+                    -2.0 * self.last_objf,
+                    -2.0 * self.objf,
+                    -2.0 * self.last_objf - -2.0 * self.objf
                 );
             }
 
@@ -327,6 +328,7 @@ where
                 stop = true;
             }
 
+            // Create state object
             let state = NPCycle {
                 cycle: self.cycle,
                 objf: -2. * self.objf,
@@ -337,14 +339,17 @@ where
                 converged: self.converged,
             };
 
+            // Update TUI with current state
             match &self.tx {
                 Some(tx) => tx.send(Comm::NPCycle(state.clone())).unwrap(),
                 None => (),
             }
 
+            // Write cycle log
             self.cycle_log
                 .push_and_write(state, self.settings.config.output);
 
+            // Break if stop criteria are met
             if stop {
                 break;
             }

--- a/src/algorithms/npod.rs
+++ b/src/algorithms/npod.rs
@@ -118,7 +118,7 @@ where
                 _ => panic!("Error type not supported"),
             },
             converged: false,
-            cycle_log: CycleLog::new(&settings.random.names()),
+            cycle_log: CycleLog::new(&settings),
             cache: settings.config.cache,
             tx,
             settings,
@@ -263,6 +263,38 @@ where
 
             self.optim_gamma();
 
+            // Increasing objf signals instability or model misspecification.
+            if self.last_objf > self.objf {
+                tracing::warn!(
+                    "Objective function decreased from {} to {}. This may indicate instability or model misspecification.",
+                    self.last_objf,
+                    self.objf
+                );
+            }
+
+            self.w = self.lambda.clone();
+
+            // Perform checks for convergence or termination
+            let mut stop = false;
+            // Stop if objective function convergence is reached
+            if (self.last_objf - self.objf).abs() <= THETA_F {
+                tracing::info!("Objective function convergence reached");
+                self.converged = true;
+                stop = true;
+            }
+            // Stop if we have reached maximum number of cycles
+            if self.cycle >= self.settings.config.cycles {
+                tracing::warn!("Maximum number of cycles reached");
+                stop = true;
+            }
+
+            // Stop if stopfile exists
+            if std::path::Path::new("stop").exists() {
+                tracing::warn!("Stopfile detected - breaking");
+                stop = true;
+            }
+
+            // Create a new NPCycle state and log it
             let state = NPCycle {
                 cycle: self.cycle,
                 objf: -2. * self.objf,
@@ -270,6 +302,7 @@ where
                 nspp: self.theta.shape()[0],
                 theta: self.theta.clone(),
                 gamlam: self.gamma,
+                converged: self.converged,
             };
 
             // Log relevant cycle information
@@ -282,46 +315,21 @@ where
                 None => (),
             }
 
-            // Increasing objf signals instability or model misspecification.
-            if self.last_objf > self.objf {
-                tracing::warn!(
-                    "Objective function decreased from {} to {}. This may indicate instability or model misspecification.",
-                    self.last_objf,
-                    self.objf
-                );
-            }
+            self.cycle_log
+                .push_and_write(state, self.settings.config.output);
 
-            self.w = self.lambda.clone();
-
-            if (self.last_objf - self.objf).abs() <= THETA_F {
-                tracing::info!("Objective function convergence reached");
-                self.converged = true;
-                break;
-            }
-            // Stop if we have reached maximum number of cycles
-            if self.cycle >= self.settings.config.cycles {
-                tracing::warn!("Maximum number of cycles reached");
+            if stop {
                 break;
             }
 
-            // Stop if stopfile exists
-            if std::path::Path::new("stop").exists() {
-                tracing::warn!("Stopfile detected - breaking");
-                break;
-            }
+            // If no stop signal, add new point to theta based on the optimization of the D function
             let pyl = self.psi.dot(&self.w);
-
-            // Add new point to theta based on the optimization of the D function
             let sigma = ErrorPoly {
                 c: self.c,
                 gl: self.gamma,
                 e_type: &self.error_type,
             };
-            // for spp in self.theta.clone().rows() {
-            //     let optimizer = SppOptimizer::new(&self.engine, &self.scenarios, &sigma, &pyl);
-            //     let candidate_point = optimizer.optimize_point(spp.to_owned()).unwrap();
-            //     prune(&mut self.theta, candidate_point, &self.ranges, THETA_D);
-            // }
+
             let mut candididate_points: Vec<Array1<f64>> = Vec::default();
             for spp in self.theta.clone().rows() {
                 candididate_points.push(spp.to_owned());
@@ -335,14 +343,8 @@ where
                 prune(&mut self.theta, cp, &self.ranges, THETA_D);
             }
 
-            //TODO: the cycle might break before reaching this point
-            self.cycle_log
-                .push_and_write(state, self.settings.config.output);
-
+            // Increment the cycle count and prepare for the next cycle
             self.cycle += 1;
-
-            // log::info!("cycle: {}, objf: {}", self.cycle, self.objf);
-            // dbg!((self.last_objf - self.objf).abs());
         }
 
         self.to_npresult()

--- a/src/algorithms/npod.rs
+++ b/src/algorithms/npod.rs
@@ -266,9 +266,10 @@ where
             // Increasing objf signals instability or model misspecification.
             if self.last_objf > self.objf {
                 tracing::warn!(
-                    "Objective function decreased from {} to {}. This may indicate instability or model misspecification.",
-                    self.last_objf,
-                    self.objf
+                    "Objective function decreased from {:.4} to {:.4} (delta = {})",
+                    -2.0 * self.last_objf,
+                    -2.0 * self.objf,
+                    -2.0 * self.last_objf - -2.0 * self.objf
                 );
             }
 

--- a/src/routines/output.rs
+++ b/src/routines/output.rs
@@ -78,7 +78,7 @@ impl NPResult {
             let theta: Array2<f64> = self.theta.clone();
             let w: Array1<f64> = self.w.clone();
 
-            let file = File::create("theta.csv")?;
+            let file = create_output_file(&self.settings, "theta.csv")?;
             let mut writer = WriterBuilder::new().has_headers(true).from_writer(file);
 
             // Create the headers
@@ -112,7 +112,8 @@ impl NPResult {
 
             let posterior = posterior(&psi, &w);
 
-            let file = File::create("posterior.csv")?;
+            // Create the output folder if it doesn't exist
+            let file = create_output_file(&self.settings, "posterior.csv")?;
             let mut writer = WriterBuilder::new().has_headers(true).from_writer(file);
 
             // Create the headers
@@ -151,7 +152,7 @@ impl NPResult {
         let result = (|| {
             let scenarios = self.scenarios.clone();
 
-            let file = File::create("obs.csv")?;
+            let file = create_output_file(&self.settings, "obs.csv")?;
             let mut writer = WriterBuilder::new().has_headers(false).from_writer(file);
 
             // Create the headers
@@ -216,7 +217,7 @@ impl NPResult {
                 false,
             );
 
-            let file = File::create("pred.csv")?;
+            let file = create_output_file(&self.settings, "pred.csv")?;
             let mut writer = WriterBuilder::new().has_headers(false).from_writer(file);
 
             // Create the headers
@@ -581,4 +582,24 @@ pub fn posterior_mean_median(
     }
 
     (mean, median)
+}
+
+pub fn create_output_file(settings: &Settings, file_name: &str) -> std::io::Result<File> {
+    let output_folder = settings
+        .paths
+        .output_folder
+        .as_ref()
+        .ok_or(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Output folder not specified in settings",
+        ))?;
+
+    let path = std::path::Path::new(output_folder);
+
+    // Attempt to create the output directory (does nothing if already exists)
+    std::fs::create_dir_all(path)?;
+
+    // Create and open the file, returning the File handle
+    let file_path = path.join(file_name);
+    File::create(file_path)
 }

--- a/src/routines/settings.rs
+++ b/src/routines/settings.rs
@@ -34,6 +34,9 @@ pub struct Paths {
     pub log: Option<String>,
     /// If provided, PMcore will use this prior instead of a "uniform" prior, see `sobol::generate` for details.
     pub prior: Option<String>,
+    /// If provided, and [Config::output] is true, PMcore will write the output to this **relative** path. Defaults to `outputs/`
+    #[serde(default = "default_output_folder")]
+    pub output_folder: Option<String>,
 }
 
 /// General configuration settings
@@ -53,6 +56,7 @@ pub struct Config {
     pub init_points: usize,
     #[serde(default = "default_false")]
     pub tui: bool,
+    /// If true (default), write outputs to files. Output path is set with [Paths::output_folder]
     #[serde(default = "default_true")]
     pub output: bool,
     /// If true (default), cache predicted values
@@ -200,7 +204,9 @@ pub fn read_settings(path: String) -> Result<Settings, config::ConfigError> {
 
     // Write a copy of the settings to file if output is enabled
     if settings.config.output {
-        write_settings_to_file(&settings).expect("Could not write settings to file");
+        if let Err(error) = write_settings_to_file(&settings) {
+            eprintln!("Could not write settings to file: {}", error);
+        }
     }
 
     Ok(settings) // Return the settings wrapped in Ok
@@ -252,4 +258,8 @@ fn default_10k() -> usize {
 
 fn default_cycles() -> usize {
     100
+}
+
+fn default_output_folder() -> Option<String> {
+    Some("outputs/".to_string())
 }

--- a/src/routines/settings.rs
+++ b/src/routines/settings.rs
@@ -219,8 +219,7 @@ pub fn write_settings_to_file(settings: &Settings) -> Result<(), std::io::Error>
     let serialized = serde_json::to_string_pretty(settings)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
-    let file_path = "settings.json";
-    let mut file = std::fs::File::create(file_path)?;
+    let mut file = crate::routines::output::create_output_file(settings, "settings.json")?;
     std::io::Write::write_all(&mut file, serialized.as_bytes())?;
     Ok(())
 }


### PR DESCRIPTION
**Changes**

- User can now choose where outputs are written to, using the `output_folder` setting under `paths`.
- `meta_rust.csv` is no longer written, but a `converged` column is written to `cycles.csv`
- Minor changes to log messages when the objective function is decreased
- `cycles.csv` is now correctly not written when `outputs` is `false`.
- `settings.json` is now also written to the `output_folder`