### PR TITLE
Provide dynamic output folder parsing

### DIFF
--- a/src/entrypoints.rs
+++ b/src/entrypoints.rs
@@ -109,7 +109,11 @@ pub fn fit(equation: Equation, settings: Settings) -> Result<NPResult> {
         subjects.iter().map(|s| s.occasions().len()).sum::<usize>()
     );
 
-    tracing::info!("Starting {}", settings.config.engine);
+    // Tell the user where the output files will be written
+    tracing::info!(
+        "Output files will be written to {}",
+        settings.paths.output_folder.as_ref().unwrap().clone()
+    );
 
     // Spawn new thread for TUI
     let settings_tui = settings.clone();
@@ -122,8 +126,16 @@ pub fn fit(equation: Equation, settings: Settings) -> Result<NPResult> {
         spawn(move || {})
     };
 
-    // Initialize algorithm and run
+    // Initialize algorithm
     let mut algorithm = initialize_algorithm(equation.clone(), settings.clone(), data, tx.clone());
+
+    // Tell the user which algorithm is being used
+    tracing::info!(
+        "The program will run with the {} algorithm",
+        settings.config.engine
+    );
+
+    // Run the algorithm
     let result = algorithm.fit();
 
     // Write output files (if configured)

--- a/src/routines/settings.rs
+++ b/src/routines/settings.rs
@@ -48,15 +48,23 @@ impl Paths {
     /// If a `#` symbol is found, it will automatically increment the number by one.
     pub fn parse_output_folder(&mut self) {
         let folder = self.output_folder.as_ref().unwrap().clone();
-        // Check for the presence of a `#` symbol
-        if folder.contains('#') {
-            let mut folder = folder.clone();
-            let mut num = 1;
-            while std::path::Path::new(&folder.replace("#", &num.to_string())).exists() {
-                num += 1;
+        // Check for the presence exactly one `#` symbol
+        let count = folder.matches('#').count();
+        match count {
+            0 => self.output_folder = Some(folder),
+            1 => {
+                let mut folder = folder.clone();
+                let mut num = 1;
+                while std::path::Path::new(&folder.replace("#", &num.to_string())).exists() {
+                    num += 1;
+                }
+                folder = folder.replace("#", &num.to_string());
+                self.output_folder = Some(folder);
             }
-            folder = folder.replace("#", &num.to_string());
-            self.output_folder = Some(folder);
+            _ => {
+                eprintln!("Only one `#` symbol is allowed in the setting folder path. Rename the `output_folder setting` in the configuration file and re-run the program.");
+                std::process::exit(-1);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR implements a new parsing for the `output_folder` location.

If the `#`-character is found in the path, it will look for folders matching the path, and if found, increment the numerical value by 1, starting at 1.

For example
`output_folder = "run_#"` will create folders `run_1`, `run_2`, and so forth.

A single `#` is also supported as the path name, creating the folders `1`, `2`, etc.