### PR TITLE
Write output files if an error occurs during model fitting

### DIFF
--- a/src/algorithms.rs
+++ b/src/algorithms.rs
@@ -16,7 +16,7 @@ mod npod;
 mod postprob;
 
 pub trait Algorithm {
-    fn fit(&mut self) -> Result<NPResult>;
+    fn fit(&mut self) -> Result<NPResult, (anyhow::Error, NPResult)>;
     fn to_npresult(&self) -> NPResult;
 }
 

--- a/src/algorithms/npag.rs
+++ b/src/algorithms/npag.rs
@@ -341,9 +341,7 @@ impl NPAG {
                 if self.eps <= THETA_E {
                     self.f1 = pyl.mapv(|x| x.ln()).sum();
                     if (self.f1 - self.f0).abs() <= THETA_F {
-                        tracing::info!(
-                            "The run converged with the following criteria: Log-Likelihood"
-                        );
+                        tracing::info!("The model converged after {} cycles", self.cycle,);
                         self.converged = true;
                         stop = true;
                     } else {

--- a/src/algorithms/npag.rs
+++ b/src/algorithms/npag.rs
@@ -55,7 +55,7 @@ pub struct NPAG {
 }
 
 impl Algorithm for NPAG {
-    fn fit(&mut self) -> anyhow::Result<NPResult> {
+    fn fit(&mut self) -> anyhow::Result<NPResult, (anyhow::Error, NPResult)> {
         self.run()
     }
     fn to_npresult(&self) -> NPResult {
@@ -224,7 +224,7 @@ impl NPAG {
         adaptative_grid(&mut self.theta, self.eps, &self.ranges, THETA_D);
     }
 
-    pub fn run(&mut self) -> anyhow::Result<NPResult> {
+    pub fn run(&mut self) -> Result<NPResult, (anyhow::Error, NPResult)> {
         loop {
             // Enter a span for each cycle, providing context for further errors
             let cycle_span = tracing::span!(tracing::Level::INFO, "Cycle", cycle = self.cycle);
@@ -241,19 +241,28 @@ impl NPAG {
                 &self.error_type,
             ));
 
-            self.validate_psi()?;
+            if let Err(err) = self.validate_psi() {
+                return Err((err, self.to_npresult()));
+            }
 
             (self.lambda, _) = match burke(&self.psi) {
                 Ok((lambda, objf)) => (lambda, objf),
                 Err(err) => {
-                    //todo: write out report
-                    panic!("Error in IPM: {:?}", err);
+                    return Err((
+                        anyhow::anyhow!("Error in IPM: {:?}", err),
+                        self.to_npresult(),
+                    ));
                 }
+            };
+
+            let max_lambda = match self.lambda.max() {
+                Ok(max_lambda) => max_lambda,
+                Err(err) => return Err((anyhow::anyhow!(err), self.to_npresult())),
             };
 
             let mut keep = Vec::<usize>::new();
             for (index, lam) in self.lambda.iter().enumerate() {
-                if *lam > self.lambda.max()? / 1000_f64 {
+                if *lam > max_lambda / 1000_f64 {
                     keep.push(index);
                 }
             }
@@ -297,8 +306,10 @@ impl NPAG {
             (self.lambda, self.objf) = match burke(&self.psi) {
                 Ok((lambda, objf)) => (lambda, objf),
                 Err(err) => {
-                    //todo: write out report
-                    panic!("Error in IPM: {:?}", err);
+                    return Err((
+                        anyhow::anyhow!("Error in IPM: {:?}", err),
+                        self.to_npresult(),
+                    ));
                 }
             };
 

--- a/src/algorithms/npod.rs
+++ b/src/algorithms/npod.rs
@@ -47,7 +47,7 @@ pub struct NPOD {
 }
 
 impl Algorithm for NPOD {
-    fn fit(&mut self) -> anyhow::Result<NPResult> {
+    fn fit(&mut self) -> anyhow::Result<NPResult, (anyhow::Error, NPResult)> {
         self.run()
     }
     fn to_npresult(&self) -> NPResult {
@@ -164,7 +164,7 @@ impl NPOD {
         }
     }
 
-    pub fn run(&mut self) -> anyhow::Result<NPResult> {
+    pub fn run(&mut self) -> Result<NPResult, (anyhow::Error, NPResult)> {
         loop {
             // Enter a span for each cycle, providing context for further errors
             let cycle_span = tracing::span!(tracing::Level::INFO, "Cycle", cycle = self.cycle);

--- a/src/algorithms/postprob.rs
+++ b/src/algorithms/postprob.rs
@@ -34,7 +34,7 @@ pub struct POSTPROB {
 }
 
 impl Algorithm for POSTPROB {
-    fn fit(&mut self) -> anyhow::Result<NPResult> {
+    fn fit(&mut self) -> anyhow::Result<NPResult, (anyhow::Error, NPResult)> {
         self.run()
     }
     fn to_npresult(&self) -> NPResult {
@@ -83,7 +83,7 @@ impl POSTPROB {
         }
     }
 
-    pub fn run(&mut self) -> anyhow::Result<NPResult> {
+    pub fn run(&mut self) -> anyhow::Result<NPResult, (anyhow::Error, NPResult)> {
         let obs_pred = get_population_predictions(&self.equation, &self.data, &self.theta, false);
 
         self.psi = obs_pred.get_psi(&ErrorModel::new(self.c, self.gamma, &self.error_type));

--- a/src/entrypoints.rs
+++ b/src/entrypoints.rs
@@ -115,7 +115,7 @@ pub fn fit(equation: Equation, data: Data, settings: Settings) -> anyhow::Result
 
             // If the settings are configured to write output files, attempt to write the output files
             // This might fail for various reasons, such as incompatible shapes, if the program errors mid-cycle
-            if settings.config.output {
+            if settings.output.write {
                 match result.write_outputs(&equation) {
                     Ok(_) => {
                         tracing::info!("Output files written successfully");
@@ -134,9 +134,14 @@ pub fn fit(equation: Equation, data: Data, settings: Settings) -> anyhow::Result
 
     // Write output files (if configured)
     if settings.output.write {
-        let idelta = settings.predictions.idelta;
-        let tad = settings.predictions.tad;
-        result.write_outputs(true, &equation, idelta, tad)?;
+        match result.write_outputs(&equation) {
+            Ok(_) => {
+                tracing::info!("Output files written successfully");
+            }
+            Err(err) => {
+                tracing::error!("An error has occurred while writing output files: {}", err);
+            }
+        };
     }
 
     if let Some(tx) = tx {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,6 @@ pub mod prelude {
     pub use crate::algorithms;
     pub use crate::entrypoints::fit;
     pub use crate::entrypoints::simulate;
-    pub use crate::entrypoints::start_internal;
     pub use crate::logger;
     pub use crate::prelude::evaluation::*;
     pub use crate::routines::condensation;

--- a/src/routines/output.rs
+++ b/src/routines/output.rs
@@ -57,14 +57,14 @@ impl NPResult {
     }
 
     pub fn write_outputs(&self, equation: &Equation) -> Result<()> {
-        if self.settings.config.output {
-            let idelta = self.settings.config.idelta;
-            let tad = self.settings.config.tad;
+        if self.settings.output.write {
+            let idelta: f64 = self.settings.predictions.idelta;
+            let tad = self.settings.predictions.tad;
             self.cyclelog.write(&self.settings)?;
+            self.write_obs().context("Failed to write observations")?;
             self.write_theta().context("Failed to write theta")?;
             self.write_posterior()
                 .context("Failed to write posterior")?;
-            self.write_obs().context("Failed to write observations")?;
             self.write_pred(equation, idelta, tad)
                 .context("Failed to write predictions")?;
         }
@@ -74,7 +74,7 @@ impl NPResult {
     /// Writes theta, which containts the population support points and their associated probabilities
     /// Each row is one support point, the last column being probability
     pub fn write_theta(&self) -> Result<()> {
-        tracing::info!("Writing population parameter distribution...");
+        tracing::debug!("Writing population parameter distribution...");
         let result: Result<(), anyhow::Error> = (|| {
             let theta: Array2<f64> = self.theta.clone();
             let w: Array1<f64> = self.w.clone();
@@ -111,22 +111,29 @@ impl NPResult {
 
     /// Writes the posterior support points for each individual
     pub fn write_posterior(&self) -> Result<()> {
-        tracing::info!("Writing posterior parameter probabilities...");
+        tracing::debug!("Writing posterior parameter probabilities...");
         let theta: Array2<f64> = self.theta.clone();
         let w: Array1<f64> = self.w.clone();
         let psi: Array2<f64> = self.psi.clone();
         let par_names: Vec<String> = self.par_names.clone();
-        //let subjects = self.subjects.clone();
 
-        // Check for compatible sizes
-        if theta.nrows() != w.len() || theta.nrows() != psi.nrows() || psi.nrows() != w.len() {
-            bail!("Number of parameters and number of weights do not match");
-        }
-
-        let posterior = posterior(&psi, &w).context("Failed to calculate posterior")?;
+        // Calculate the posterior probabilities
+        let posterior = match posterior(&psi, &w) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::error!("Failed to calculate posterior: {}", e);
+                return Err(e.context("Failed to calculate posterior"));
+            }
+        };
 
         // Create the output folder if it doesn't exist
-        let outputfile = OutputFile::new(&self.settings.output.path, "posterior.csv")?;
+        let outputfile = match OutputFile::new(&self.settings.output.path, "posterior.csv") {
+            Ok(of) => of,
+            Err(e) => {
+                tracing::error!("Failed to create output file: {}", e);
+                return Err(e.context("Failed to create output file"));
+            }
+        };
         let mut writer = WriterBuilder::new()
             .has_headers(true)
             .from_writer(&outputfile.file);
@@ -165,9 +172,9 @@ impl NPResult {
 
     /// Write the observations, which is the reformatted input data
     pub fn write_obs(&self) -> Result<()> {
-        tracing::info!("Writing observations...");
+        tracing::debug!("Writing observations...");
         let outputfile = OutputFile::new(&self.settings.output.path, "obs.csv")?;
-        write_pmetrics_observations(&self.data, &outputfile.file);
+        write_pmetrics_observations(&self.data, &outputfile.file)?;
         tracing::info!(
             "Observations written to {:?}",
             &outputfile.get_relative_path()
@@ -177,17 +184,12 @@ impl NPResult {
 
     /// Writes the predictions
     pub fn write_pred(&self, equation: &Equation, idelta: f64, tad: f64) -> Result<()> {
-        tracing::info!("Writing predictions...");
+        tracing::debug!("Writing predictions...");
         let data = self.data.expand(idelta, tad);
 
         let theta: Array2<f64> = self.theta.clone();
         let w: Array1<f64> = self.w.clone();
         let psi: Array2<f64> = self.psi.clone();
-
-        // Check for compatible sizes
-        if theta.nrows() != w.len() || theta.nrows() != psi.nrows() || psi.nrows() != w.len() {
-            bail!("Number of parameters and number of weights do not match");
-        }
 
         let (post_mean, post_median) = posterior_mean_median(&theta, &psi, &w)
             .context("Failed to calculate posterior mean and median")?;
@@ -337,7 +339,7 @@ impl CycleLog {
     }
 
     pub fn write(&self, settings: &Settings) -> Result<()> {
-        tracing::info!("Writing cycles...");
+        tracing::debug!("Writing cycles...");
         let outputfile = OutputFile::new(&settings.output.path, "cycles.csv")?;
         let mut writer = WriterBuilder::new()
             .has_headers(false)
@@ -498,16 +500,14 @@ pub fn posterior_mean_median(
     let mut median = Array2::zeros((0, theta.ncols()));
 
     // Check for compatible sizes
-    if theta.nrows() != w.len() || theta.nrows() != psi.nrows() || psi.nrows() != w.len() {
+    if theta.nrows() != w.len() || theta.nrows() != psi.ncols() || psi.ncols() != w.len() {
         bail!("Number of parameters and number of weights do not match");
     }
 
     // Normalize psi to get probabilities of each spp for each id
     let mut psi_norm: Array2<f64> = Array2::zeros((0, psi.ncols()));
     for row in psi.axis_iter(Axis(0)) {
-        tracing::warn!("Normalizing row");
         let row_w = row.to_owned() * w.to_owned();
-        tracing::warn!("Normalizing row finished");
         let row_sum = row_w.sum();
         let row_norm = &row_w / row_sum;
         psi_norm.push_row(row_norm.view())?;
@@ -574,33 +574,30 @@ impl OutputFile {
     }
 }
 
-pub fn write_pmetrics_observations(data: &Data, file: &std::fs::File) {
+pub fn write_pmetrics_observations(data: &Data, file: &std::fs::File) -> Result<()> {
     let mut writer = WriterBuilder::new().has_headers(true).from_writer(file);
 
-    writer
-        .write_record(&["id", "block", "time", "out", "outeq"])
-        .unwrap();
+    writer.write_record(&["id", "block", "time", "out", "outeq"])?;
     for subject in data.get_subjects() {
         for occasion in subject.occasions() {
             for event in occasion.get_events(None, None, false) {
                 match event {
                     Event::Observation(obs) => {
                         // Write each field individually
-                        writer
-                            .write_record(&[
-                                &subject.id(),
-                                &occasion.index().to_string(),
-                                &obs.time().to_string(),
-                                &obs.value().to_string(),
-                                &obs.outeq().to_string(),
-                            ])
-                            .unwrap();
+                        writer.write_record(&[
+                            &subject.id(),
+                            &occasion.index().to_string(),
+                            &obs.time().to_string(),
+                            &obs.value().to_string(),
+                            &obs.outeq().to_string(),
+                        ])?;
                     }
                     _ => {}
                 }
             }
         }
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/routines/output.rs
+++ b/src/routines/output.rs
@@ -468,6 +468,12 @@ pub fn population_mean_median(
     theta: &Array2<f64>,
     w: &Array1<f64>,
 ) -> Result<(Array1<f64>, Array1<f64>)> {
+
+    // Check for compatible sizes
+    if theta.nrows() != w.len() {
+        bail!("Number of parameters and number of weights do not match. Theta: {}, w: {}", theta.nrows(), w.len());
+    }
+
     let mut mean = Array1::zeros(theta.ncols());
     let mut median = Array1::zeros(theta.ncols());
 

--- a/src/routines/output.rs
+++ b/src/routines/output.rs
@@ -468,10 +468,13 @@ pub fn population_mean_median(
     theta: &Array2<f64>,
     w: &Array1<f64>,
 ) -> Result<(Array1<f64>, Array1<f64>)> {
-
     // Check for compatible sizes
     if theta.nrows() != w.len() {
-        bail!("Number of parameters and number of weights do not match. Theta: {}, w: {}", theta.nrows(), w.len());
+        bail!(
+            "Number of parameters and number of weights do not match. Theta: {}, w: {}",
+            theta.nrows(),
+            w.len()
+        );
     }
 
     let mut mean = Array1::zeros(theta.ncols());

--- a/src/routines/settings.rs
+++ b/src/routines/settings.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use anyhow::{bail, Result};
 use config::Config as eConfig;
 use pharmsol::prelude::data::ErrorType;
 use serde::Deserialize;
@@ -7,7 +8,6 @@ use serde_derive::Serialize;
 use serde_json;
 use std::collections::HashMap;
 use toml::Table;
-use anyhow::{bail, Result};
 
 /// Contains all settings for PMcore
 #[derive(Debug, Deserialize, Clone, Serialize)]

--- a/src/routines/settings.rs
+++ b/src/routines/settings.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use super::output::OutputFile;
 use anyhow::{bail, Result};
 use config::Config as eConfig;
 use pharmsol::prelude::data::ErrorType;
@@ -8,7 +9,6 @@ use serde_derive::Serialize;
 use serde_json;
 use std::collections::HashMap;
 use toml::Table;
-use super::output::OutputFile;
 
 /// Contains all settings for PMcore
 #[derive(Debug, Deserialize, Clone, Serialize)]


### PR DESCRIPTION
This allows the user restart the model with the given theta. Note: depending on where the algorithm failed, the theta may be subject to another iteration of the adaptive grid - causing incompatible shapes for calculating the posterior. This too is wrapped, but potentially not exhaustibly.

Additionally, `write_outputs` now only relies on `self.settings`, instead of manually providing the arguments.