### PR TITLE
chore: Update QR-decomposition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ tracing-subscriber = { version = "0.3.17", features = [
     "time",
 ] }
 config = { version = "0.15", features = ["preserve_order"] }
-faer = "0.20.2"
-faer-ext = { version = "0.4.1", features = ["nalgebra", "ndarray"] }
+faer = "0.21.5"
+faer-ext = { version = "0.5.0", features = ["nalgebra", "ndarray"] }
 pharmsol = "0.7.6"
 rand = "0.9.0"
 anyhow = "1.0.86"

--- a/src/routines/evaluation/qr.rs
+++ b/src/routines/evaluation/qr.rs
@@ -2,19 +2,29 @@ use faer_ext::*;
 use ndarray::parallel::prelude::*;
 use ndarray::{Array2, Axis};
 
+use faer::linalg::solvers::ColPivQr;
+use faer::perm::PermRef;
 use faer::MatRef;
 
 pub fn calculate_r(x: &Array2<f64>) -> (Array2<f64>, Vec<usize>) {
+    // Normalize rows to sum to 1
     let mut n_x = x.clone();
     n_x.axis_iter_mut(Axis(0))
         .into_par_iter()
         .for_each(|mut row| row /= row.sum());
+
+    // Convert to faer matrix format
     let mat_x: MatRef<'_, f64> = n_x.view().into_faer();
-    let qr: faer::sparse::solvers::ColPivQr<f64> = mat_x.col_piv_qr();
-    let r_mat: faer::Mat<f64> = qr.compute_r();
-    let (forward, _inverse) = qr.col_permutation().arrays();
-    let r: ndarray::ArrayBase<ndarray::OwnedRepr<f64>, ndarray::Dim<[usize; 2]>> =
-        r_mat.as_ref().into_ndarray().to_owned();
-    let perm: Vec<usize> = Vec::from(forward);
+
+    // Perform column pivoted QR decomposition
+    let qr: ColPivQr<f64> = mat_x.col_piv_qr();
+
+    // Extract the R matrix
+    let r_mat: faer::Mat<f64> = qr.R().to_owned();
+    let r = r_mat.as_ref().into_ndarray().to_owned();
+
+    // Get the permutation information
+    let perm: PermRef<'_, usize> = qr.P();
+    let perm_vec: Vec<usize> = perm.as_ref().into();
     (r, perm)
 }

--- a/src/routines/evaluation/qr.rs
+++ b/src/routines/evaluation/qr.rs
@@ -3,7 +3,6 @@ use ndarray::parallel::prelude::*;
 use ndarray::{Array2, Axis};
 
 use faer::linalg::solvers::ColPivQr;
-use faer::perm::PermRef;
 use faer::MatRef;
 
 pub fn calculate_r(x: &Array2<f64>) -> (Array2<f64>, Vec<usize>) {
@@ -24,7 +23,6 @@ pub fn calculate_r(x: &Array2<f64>) -> (Array2<f64>, Vec<usize>) {
     let r = r_mat.as_ref().into_ndarray().to_owned();
 
     // Get the permutation information
-    let perm: PermRef<'_, usize> = qr.P();
-    let perm_vec: Vec<usize> = perm.as_ref().into();
+    let perm = qr.P().arrays().0.to_vec();
     (r, perm)
 }


### PR DESCRIPTION
Now uses the latest version of `faer` and `faer-ext`.

This function needs better test-coverage, but will need help from @Siel to create meaningful tests.