### PR TITLE
benchmarks: Improve benchmark coverage

### DIFF
--- a/benches/bimodal_ke.rs
+++ b/benches/bimodal_ke.rs
@@ -102,6 +102,6 @@ fn benchmark_bimodal_ke_postprob(c: &mut Criterion) {
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = benchmark_bimodal_ke_npag, benchmark_bimodal_ke_npod, benchmark_bimodal_ke_postprob,
+    targets = benchmark_bimodal_ke_npag, benchmark_bimodal_ke_npod, benchmark_bimodal_ke_postprob
 }
 criterion_main!(benches);


### PR DESCRIPTION
Ensure that all algorithms are benchmarked. Comparing the benchmarks of e.g. NPAG/NPOD with POSTPROB yields some information about the minimum time required for the algorithm, providing context for eventual increases in simulation time.