### PR TITLE
ci: Update CI workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ permissions:
   contents: read
 
 name: Build
-'on':
+"on":
   push:
     branches:
       - main
@@ -11,17 +11,32 @@ name: Build
       - main
 
 concurrency:
-  group: '${{ github.workflow }}-${{ github.ref }}'
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
   test:
-    runs-on: '${{ matrix.os }}'
-    name: '${{ matrix.os }} / stable'
+    needs: lint
+    runs-on: "${{ matrix.os }}"
+    name: "${{ matrix.os }} / stable"
     strategy:
       fail-fast: false
       matrix:
@@ -32,41 +47,27 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-      
+
       - name: Setup cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-      
+        uses: Swatinem/rust-cache@v2
+
       - name: Build (no features)
         run: cargo build --verbose --no-default-features
-      
+
       - name: Build (default features)
         run: cargo build --verbose
-      
+
       - name: Build (all features)
         run: cargo build --verbose --all-features
-      
+
       - name: Run tests (no features)
         run: cargo test --verbose --no-default-features
-      
+
       - name: Run tests (default features)
         run: cargo test --verbose
-      
+
       - name: Run tests (all features)
         run: cargo test --verbose --all-features
-      
-      - name: Run doc tests
-        run: cargo test --doc --all-features

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -14,9 +14,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-      - name: Run security audit
-        run: cargo audit
+      - name: Security audit
+        uses: rustsec/audit-check@v2.0.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,7 +1,9 @@
 name: Security Audit
 
-'on':
+"on":
   workflow_dispatch:
+  schedule:
+    - cron: "0 6 1,15 * *"
 
 permissions:
   contents: read
@@ -13,13 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Setup cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        uses: Swatinem/rust-cache@v2
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Run security audit

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Security audit
-        uses: rustsec/audit-check@v2.0.2
+        uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Attempts to save compute time.

Runs `cargo fmt` only on Ubuntu, and before all other checks.
Uses a consistent cache strategy.
Runs security-audits bi-weekly.