### PR TITLE
chore: Use pharmsol 0.28.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tracing-subscriber = { version = "0.3.19", features = [
     "time",
 ] }
 faer = "0.24.0"
-pharmsol = { version = "=0.28.2" }
+pharmsol = { version = "=0.28.3" }
 anyhow = "1.0.100"
 rayon = "1.10.0"
 rand = "0.10.1"


### PR DESCRIPTION
Exposes `t` and `time` in the DSL for getting the current time.